### PR TITLE
ZOOM-218 - Prevent API calls

### DIFF
--- a/Model/Datasource/AdobeConnectSource.php
+++ b/Model/Datasource/AdobeConnectSource.php
@@ -343,6 +343,11 @@ class AdobeConnectSource extends DataSource {
 			throw new OutOfBoundsException("$alias::request: missing action " . json_encode($data));
 			return false;
 		}
+
+        /**
+         * Post Zoom Deployment - Don't attempt Connect Log-in
+         * Just log request for audit purposes & return early
+         * 
 		if (empty($data['session']) && $data['action'] != 'common-info') {
 			$data['session'] = $this->getSessionKey($this->userKey);
 			if (empty($data['session'])) {
@@ -351,11 +356,16 @@ class AdobeConnectSource extends DataSource {
 				throw new AdobeConnectException($text);
 			}
 		}
+         * */
 
 		//Scrub the data so it's ready for request.
 		$data = $this->__requestPassableData($data);
 		//dataCleaned is what isn't model specific data
 		$dataCleaned = array_diff_key($data, $this->keysDataCleanRestricted);
+
+        // Log any requests for audit/removal and return
+        $this->log($data);
+        return [];
 
 		// setup request
 		$requestOptions = Set::merge(array(


### PR DESCRIPTION
This PR prevents the infinite recursion loop we were seeing after the Connect servers were taken offline. These changes will log any requests to Connect, and return early before executing any external HTTP calls.

With https://github.com/AudiologyHoldings/SP/pull/4398, all remaining references to Connect from the LCMS should be removed so this plugin should not be invoked after that is deployed. However, this plugin will continue to log requests so we can see if any unwanted/errant calls are still being made.