### PR TITLE
ZOOM-282 - Prevent API calls

### DIFF
--- a/Model/Datasource/AdobeConnectSource.php
+++ b/Model/Datasource/AdobeConnectSource.php
@@ -343,6 +343,11 @@ class AdobeConnectSource extends DataSource {
 			throw new OutOfBoundsException("$alias::request: missing action " . json_encode($data));
 			return false;
 		}
+
+        /**
+         * Post Zoom Deployment - Don't attempt Connect Log-in
+         * Just log request for audit purposes & return early
+         * 
 		if (empty($data['session']) && $data['action'] != 'common-info') {
 			$data['session'] = $this->getSessionKey($this->userKey);
 			if (empty($data['session'])) {
@@ -351,11 +356,16 @@ class AdobeConnectSource extends DataSource {
 				throw new AdobeConnectException($text);
 			}
 		}
+         * */
 
 		//Scrub the data so it's ready for request.
 		$data = $this->__requestPassableData($data);
 		//dataCleaned is what isn't model specific data
 		$dataCleaned = array_diff_key($data, $this->keysDataCleanRestricted);
+
+        // Log any requests for audit/removal and return
+        $this->log($data);
+        return [];
 
 		// setup request
 		$requestOptions = Set::merge(array(

--- a/Model/Datasource/AdobeConnectSource.php
+++ b/Model/Datasource/AdobeConnectSource.php
@@ -315,7 +315,7 @@ class AdobeConnectSource extends DataSource {
 	 * @return mixed Depending on what is returned from HttpSocket::request()
 	 */
 	public function request($model_or_null, $data = array(), $requestOptions = array()) {
-        if ($this->config['enabled'] && $this->config['enabled'] === false) {
+        if (array_key_exists('enabled', $this->config) && $this->config['enabled'] === false) {
             $this->log($this->__requestPassableData($this->__requestPassableData($data)));
             return [];
         }

--- a/Model/Datasource/AdobeConnectSource.php
+++ b/Model/Datasource/AdobeConnectSource.php
@@ -315,6 +315,10 @@ class AdobeConnectSource extends DataSource {
 	 * @return mixed Depending on what is returned from HttpSocket::request()
 	 */
 	public function request($model_or_null, $data = array(), $requestOptions = array()) {
+        if (empty($this->config['url'])) {
+            $this->log($this->__requestPassableData($data));
+            return [];
+        }
 		if (!is_array($data)) {
 			$data = array();
 		}
@@ -344,10 +348,6 @@ class AdobeConnectSource extends DataSource {
 			return false;
 		}
 
-        /**
-         * Post Zoom Deployment - Don't attempt Connect Log-in
-         * Just log request for audit purposes & return early
-         * 
 		if (empty($data['session']) && $data['action'] != 'common-info') {
 			$data['session'] = $this->getSessionKey($this->userKey);
 			if (empty($data['session'])) {
@@ -356,16 +356,11 @@ class AdobeConnectSource extends DataSource {
 				throw new AdobeConnectException($text);
 			}
 		}
-         * */
 
 		//Scrub the data so it's ready for request.
 		$data = $this->__requestPassableData($data);
 		//dataCleaned is what isn't model specific data
 		$dataCleaned = array_diff_key($data, $this->keysDataCleanRestricted);
-
-        // Log any requests for audit/removal and return
-        $this->log($data);
-        return [];
 
 		// setup request
 		$requestOptions = Set::merge(array(

--- a/Model/Datasource/AdobeConnectSource.php
+++ b/Model/Datasource/AdobeConnectSource.php
@@ -315,8 +315,8 @@ class AdobeConnectSource extends DataSource {
 	 * @return mixed Depending on what is returned from HttpSocket::request()
 	 */
 	public function request($model_or_null, $data = array(), $requestOptions = array()) {
-        if (empty($this->config['url'])) {
-            $this->log($this->__requestPassableData($data));
+        if ($this->config['enabled'] && $this->config['enabled'] === false) {
+            $this->log($this->__requestPassableData($this->__requestPassableData($data)));
             return [];
         }
 		if (!is_array($data)) {


### PR DESCRIPTION
This PR introduces an optional `enabled` configuration that will prevent any API calls out to connect if that is set to false.
```php
'enabled' = false, // All API calls from AdobeConnect plugin will short circuit
```

With AudiologyHoldings/SP#4398, all remaining references to Connect from the LCMS should be removed so this plugin should not be invoked after that is deployed. However, this plugin will continue to log requests so we can see if any unwanted/errant calls are still being made.